### PR TITLE
Rename the existing use of "image" to "video" to better reflect actual source media type

### DIFF
--- a/backend/src/tracks/queues.constants.ts
+++ b/backend/src/tracks/queues.constants.ts
@@ -1,2 +1,2 @@
 export const TRACK_IMPORT_QUEUE = "track-import"
-export const IMAGE_IMPORT_QUEUE = "image-import"
+export const VIDEO_IMPORT_QUEUE = "video-import"

--- a/backend/src/tracks/track-images/import/video-import.processor.ts
+++ b/backend/src/tracks/track-images/import/video-import.processor.ts
@@ -8,14 +8,14 @@ import { TracksService } from "../../tracks.service"
 import { TrackImage } from "../track-image.entity"
 import { Inject, forwardRef } from "@nestjs/common"
 import { EventEmitter2 } from "@nestjs/event-emitter"
-import { IMAGE_IMPORT_QUEUE } from "src/tracks/queues.constants"
+import { VIDEO_IMPORT_QUEUE } from "src/tracks/queues.constants"
 
-export interface ImageImportPayload {
+export interface VideoImportPayload {
   trackId: number
 }
 
-@Processor(IMAGE_IMPORT_QUEUE)
-export class ImageImportProcessor extends WorkerHost {
+@Processor(VIDEO_IMPORT_QUEUE)
+export class VideoImportProcessor extends WorkerHost {
   constructor(
     @Inject(forwardRef(() => TracksService))
     private readonly tracksService: TracksService,
@@ -24,7 +24,7 @@ export class ImageImportProcessor extends WorkerHost {
     super()
   }
 
-  async process(job: Job<ImageImportPayload>): Promise<any> {
+  async process(job: Job<VideoImportPayload>): Promise<any> {
     const trackId = job.data.trackId
     const track = await this.tracksService.get(trackId)
     const videoPath = track.filePath

--- a/backend/src/tracks/tracks.module.ts
+++ b/backend/src/tracks/tracks.module.ts
@@ -5,12 +5,12 @@ import { Module } from "@nestjs/common"
 import { TypeOrmModule } from "@nestjs/typeorm"
 import { TrackImportProcessor } from "./import/track-import.processor"
 import { ImagesController } from "./track-images/images.controller"
-import { ImageImportProcessor } from "./track-images/import/image-import.processor"
+import { VideoImportProcessor } from "./track-images/import/video-import.processor"
 import { TrackImage } from "./track-images/track-image.entity"
 import { Track } from "./track.entity"
 import { TracksController } from "./tracks.controller"
 import { TracksService } from "./tracks.service"
-import { IMAGE_IMPORT_QUEUE, TRACK_IMPORT_QUEUE } from "./queues.constants"
+import { VIDEO_IMPORT_QUEUE, TRACK_IMPORT_QUEUE } from "./queues.constants"
 
 @Module({
   imports: [
@@ -20,7 +20,7 @@ import { IMAGE_IMPORT_QUEUE, TRACK_IMPORT_QUEUE } from "./queues.constants"
         name: TRACK_IMPORT_QUEUE,
       },
       {
-        name: IMAGE_IMPORT_QUEUE,
+        name: VIDEO_IMPORT_QUEUE,
       },
     ),
     BullBoardModule.forFeature(
@@ -29,12 +29,12 @@ import { IMAGE_IMPORT_QUEUE, TRACK_IMPORT_QUEUE } from "./queues.constants"
         adapter: BullMQAdapter,
       },
       {
-        name: IMAGE_IMPORT_QUEUE,
+        name: VIDEO_IMPORT_QUEUE,
         adapter: BullMQAdapter,
       },
     ),
   ],
-  providers: [TracksService, TrackImportProcessor, ImageImportProcessor],
+  providers: [TracksService, TrackImportProcessor, VideoImportProcessor],
   controllers: [TracksController, ImagesController],
   exports: [TracksService],
 })

--- a/backend/src/tracks/tracks.service.ts
+++ b/backend/src/tracks/tracks.service.ts
@@ -9,10 +9,10 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import { DeepPartial, Repository } from "typeorm"
 import { TrackImportPayload } from "./import/track-import.processor"
-import { ImageImportPayload } from "./track-images/import/image-import.processor"
+import { VideoImportPayload } from "./track-images/import/video-import.processor"
 import { TrackImage } from "./track-images/track-image.entity"
 import { Track } from "./track.entity"
-import { IMAGE_IMPORT_QUEUE, TRACK_IMPORT_QUEUE } from "./queues.constants"
+import { VIDEO_IMPORT_QUEUE, TRACK_IMPORT_QUEUE } from "./queues.constants"
 
 export interface TrackFilters {
   start?: Date
@@ -33,8 +33,8 @@ export class TracksService {
     @InjectQueue(TRACK_IMPORT_QUEUE)
     private trackImportQueue: Queue<TrackImportPayload>,
 
-    @InjectQueue(IMAGE_IMPORT_QUEUE)
-    private imageImportQueue: Queue<ImageImportPayload>,
+    @InjectQueue(VIDEO_IMPORT_QUEUE)
+    private videoImportQueue: Queue<VideoImportPayload>,
   ) {}
 
   list(filters: TrackFilters = {}): Promise<Track[]> {
@@ -156,11 +156,11 @@ export class TracksService {
 
   @OnEvent("track.imported")
   handleTrackImported({ id }: { id: number; name: string }) {
-    this.imageImportQueue.add(id.toString(), { trackId: id })
+    this.videoImportQueue.add(id.toString(), { trackId: id })
   }
 
-  async startImageImport(trackId: number) {
-    return this.imageImportQueue.add(trackId.toString(), { trackId })
+  async startVideoImport(trackId: number) {
+    return this.videoImportQueue.add(trackId.toString(), { trackId })
   }
 
   async processMissingImages() {
@@ -176,7 +176,7 @@ export class TracksService {
       data: { trackId: track.id },
     }))
 
-    return this.imageImportQueue.addBulk(jobs)
+    return this.videoImportQueue.addBulk(jobs)
   }
 
   toGeoJSON<T extends Feature>(tracks: { toGeoJSON(): T }[]) {


### PR DESCRIPTION
Breaking this out from https://github.com/tjhorner/streetlens/pull/3 as this can be merged independent of those changes.

No obvious errors in the logs and UI functionality all seems to work:

<img width="1088" height="306" alt="Screenshot from 2026-03-24 11-27-49" src="https://github.com/user-attachments/assets/921b20aa-2942-45af-9874-8a5a415f55e1" />
<img width="1827" height="954" alt="Screenshot from 2026-03-24 11-27-21" src="https://github.com/user-attachments/assets/65e04a79-d997-4cc4-ae1c-a4765b327368" />
